### PR TITLE
Updated the naming convention of previous files to match OpenCensus and implemented aggregation logic for running spans

### DIFF
--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TraceZDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TraceZDataAggregator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.zpages;
+
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A {@link SpanProcessor} implementation for the traceZ zPage.
+ *
+ * <p>Configuration options for {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor} can
+ * be read from system properties, environment variables, or {@link java.util.Properties} objects.
+ *
+ * <p>For system properties and {@link java.util.Properties} objects, {@link
+ * io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor} will look for the following names:
+ *
+ * <ul>
+ *   <li>{@code otel.ssp.export.sampled}: sets whether only sampled spans should be exported.
+ * </ul>
+ *
+ * <p>For environment variables, {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}
+ * will look for the following names:
+ *
+ * <ul>
+ *   <li>{@code OTEL_SSP_EXPORT_SAMPLED}: sets whether only sampled spans should be exported.
+ * </ul>
+ */
+@ThreadSafe
+public final class TraceZDataAggregator {
+  private final TraceZSpanProcessor spanProcessor;
+
+  /**
+   * Constructor for {@link io.opentelemetry.sdk.contrib.zpages.TraceZDataAggregator}.
+   *
+   * @param spanProcessor collects span data.
+   */
+  public TraceZDataAggregator(TraceZSpanProcessor spanProcessor) {
+    this.spanProcessor = spanProcessor;
+  }
+
+  /**
+   * Returns a Collection of all running spans for {@link
+   * io.opentelemetry.sdk.contrib.zpages.TraceZDataAggregator}.
+   *
+   * @param spanName name to filter returned spans.
+   * @return a List of {@link io.opentelemetry.sdk.trace.data.SpanData}.\
+   */
+  public List<SpanData> getRunningSpansByName(String spanName) {
+    Collection<ReadableSpan> allRunningSpans = spanProcessor.getRunningSpans();
+    List<SpanData> runningSpanData = new ArrayList<>();
+    for (ReadableSpan span : allRunningSpans) {
+      if (span.getName().equals(spanName)) {
+        runningSpanData.add(span.toSpanData());
+      }
+    }
+    return runningSpanData;
+  }
+}

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -25,41 +25,27 @@ import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * A {@link SpanProcessor} implementation for the traceZ zPage.
+ * A data aggregator for the traceZ zPage.
  *
- * <p>Configuration options for {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor} can
- * be read from system properties, environment variables, or {@link java.util.Properties} objects.
- *
- * <p>For system properties and {@link java.util.Properties} objects, {@link
- * io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor} will look for the following names:
- *
- * <ul>
- *   <li>{@code otel.ssp.export.sampled}: sets whether only sampled spans should be exported.
- * </ul>
- *
- * <p>For environment variables, {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}
- * will look for the following names:
- *
- * <ul>
- *   <li>{@code OTEL_SSP_EXPORT_SAMPLED}: sets whether only sampled spans should be exported.
- * </ul>
+ * <p>The traceZ data aggregator complies information about the running spans, span latencies, and
+ * error spans for the frontend of the zPage.
  */
 @ThreadSafe
-public final class TraceZDataAggregator {
-  private final TraceZSpanProcessor spanProcessor;
+public final class TracezDataAggregator {
+  private final TracezSpanProcessor spanProcessor;
 
   /**
-   * Constructor for {@link io.opentelemetry.sdk.contrib.zpages.TraceZDataAggregator}.
+   * Constructor for {@link io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
    * @param spanProcessor collects span data.
    */
-  public TraceZDataAggregator(TraceZSpanProcessor spanProcessor) {
+  public TracezDataAggregator(TracezSpanProcessor spanProcessor) {
     this.spanProcessor = spanProcessor;
   }
 
   /**
-   * Returns a Collection of all running spans for {@link
-   * io.opentelemetry.sdk.contrib.zpages.TraceZDataAggregator}.
+   * Returns a List of all running spans for {@link
+   * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
    * @param spanName name to filter returned spans.
    * @return a List of {@link io.opentelemetry.sdk.trace.data.SpanData}.\

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -17,11 +17,12 @@
 package io.opentelemetry.sdk.contrib.zpages;
 
 import io.opentelemetry.sdk.trace.ReadableSpan;
-import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -44,7 +45,23 @@ public final class TracezDataAggregator {
   }
 
   /**
-   * Returns a List of all running spans for {@link
+   * Returns a Map of the running span counts for {@link
+   * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
+   *
+   * @return a Map of span counts for each span name.\
+   */
+  public Map<String, Integer> getRunningSpanCounts() {
+    Collection<ReadableSpan> allRunningSpans = spanProcessor.getRunningSpans();
+    Map<String, Integer> numSpansPerName = new HashMap<>();
+    for (ReadableSpan span : allRunningSpans) {
+      Integer prevValue = numSpansPerName.get(span.getName());
+      numSpansPerName.put(span.getName(), prevValue != null ? prevValue + 1 : 1);
+    }
+    return numSpansPerName;
+  }
+
+  /**
+   * Returns a List of all running spans with a given span name for {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
    * @param spanName name to filter returned spans.

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -28,7 +28,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * A data aggregator for the traceZ zPage.
  *
- * <p>The traceZ data aggregator complies information about the running spans, span latencies, and
+ * <p>The traceZ data aggregator compiles information about the running spans, span latencies, and
  * error spans for the frontend of the zPage.
  */
 @ThreadSafe
@@ -48,7 +48,7 @@ public final class TracezDataAggregator {
    * Returns a Map of the running span counts for {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
-   * @return a Map of span counts for each span name.\
+   * @return a Map of span counts for each span name.
    */
   public Map<String, Integer> getRunningSpanCounts() {
     Collection<ReadableSpan> allRunningSpans = spanProcessor.getRunningSpans();
@@ -65,16 +65,16 @@ public final class TracezDataAggregator {
    * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
    * @param spanName name to filter returned spans.
-   * @return a List of {@link io.opentelemetry.sdk.trace.data.SpanData}.\
+   * @return a List of {@link io.opentelemetry.sdk.trace.data.SpanData}.
    */
   public List<SpanData> getRunningSpansByName(String spanName) {
     Collection<ReadableSpan> allRunningSpans = spanProcessor.getRunningSpans();
-    List<SpanData> runningSpanData = new ArrayList<>();
+    List<SpanData> filteredSpans = new ArrayList<>();
     for (ReadableSpan span : allRunningSpans) {
       if (span.getName().equals(spanName)) {
-        runningSpanData.add(span.toSpanData());
+        filteredSpans.add(span.toSpanData());
       }
     }
-    return runningSpanData;
+    return filteredSpans;
   }
 }

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessor.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessor.java
@@ -109,7 +109,7 @@ public final class TracezSpanProcessor implements SpanProcessor {
    * Returns a Collection of all running spans for {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
-   * @return a Collection of {@link io.opentelemetry.sdk.trace.ReadableSpan}.\
+   * @return a Collection of {@link io.opentelemetry.sdk.trace.ReadableSpan}.
    */
   public Collection<ReadableSpan> getRunningSpans() {
     synchronized (this) {
@@ -121,7 +121,7 @@ public final class TracezSpanProcessor implements SpanProcessor {
    * Returns a Collection of all completed spans for {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
-   * @return a Collection of {@link io.opentelemetry.sdk.trace.ReadableSpan}.\
+   * @return a Collection of {@link io.opentelemetry.sdk.trace.ReadableSpan}.
    */
   public Collection<ReadableSpan> getCompletedSpans() {
     synchronized (this) {
@@ -132,7 +132,7 @@ public final class TracezSpanProcessor implements SpanProcessor {
   /**
    * Returns a new Builder for {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
-   * @return a new {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.\
+   * @return a new {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    */
   public static Builder newBuilder() {
     return new Builder();

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessor.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessor.java
@@ -29,17 +29,17 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * A {@link SpanProcessor} implementation for the traceZ zPage.
  *
- * <p>Configuration options for {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor} can
+ * <p>Configuration options for {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor} can
  * be read from system properties, environment variables, or {@link java.util.Properties} objects.
  *
  * <p>For system properties and {@link java.util.Properties} objects, {@link
- * io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor} will look for the following names:
+ * io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor} will look for the following names:
  *
  * <ul>
  *   <li>{@code otel.ssp.export.sampled}: sets whether only sampled spans should be exported.
  * </ul>
  *
- * <p>For environment variables, {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}
+ * <p>For environment variables, {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}
  * will look for the following names:
  *
  * <ul>
@@ -47,17 +47,17 @@ import javax.annotation.concurrent.ThreadSafe;
  * </ul>
  */
 @ThreadSafe
-public final class TraceZSpanProcessor implements SpanProcessor {
+public final class TracezSpanProcessor implements SpanProcessor {
   private final Map<SpanId, ReadableSpan> runningSpanCache;
   private final Map<SpanId, ReadableSpan> completedSpanCache;
   private final boolean sampled;
 
   /**
-   * Constructor for {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.
+   * Constructor for {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
    * @param sampled report only sampled spans.
    */
-  public TraceZSpanProcessor(boolean sampled) {
+  public TracezSpanProcessor(boolean sampled) {
     runningSpanCache = new HashMap<>();
     completedSpanCache = new HashMap<>();
     this.sampled = sampled;
@@ -107,7 +107,7 @@ public final class TraceZSpanProcessor implements SpanProcessor {
 
   /**
    * Returns a Collection of all running spans for {@link
-   * io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.
+   * io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
    * @return a Collection of {@link io.opentelemetry.sdk.trace.ReadableSpan}.\
    */
@@ -119,7 +119,7 @@ public final class TraceZSpanProcessor implements SpanProcessor {
 
   /**
    * Returns a Collection of all completed spans for {@link
-   * io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.
+   * io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
    * @return a Collection of {@link io.opentelemetry.sdk.trace.ReadableSpan}.\
    */
@@ -130,15 +130,15 @@ public final class TraceZSpanProcessor implements SpanProcessor {
   }
 
   /**
-   * Returns a new Builder for {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.
+   * Returns a new Builder for {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
-   * @return a new {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.\
+   * @return a new {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.\
    */
   public static Builder newBuilder() {
     return new Builder();
   }
 
-  /** Builder class for {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}. */
+  /** Builder class for {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}. */
   public static final class Builder extends ConfigBuilder<Builder> {
 
     private static final String KEY_SAMPLED = "otel.ssp.export.sampled";
@@ -185,12 +185,12 @@ public final class TraceZSpanProcessor implements SpanProcessor {
     }
 
     /**
-     * Returns a new {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.
+     * Returns a new {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
      *
-     * @return a new {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.
+     * @return a new {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
      */
-    public io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor build() {
-      return new io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor(sampled);
+    public io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor build() {
+      return new io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor(sampled);
     }
   }
 }

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.zpages;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.MockitoAnnotations;
+
+/** Unit tests for {@link TracezDataAggregator}. */
+@RunWith(JUnit4.class)
+public final class TracezDataAggregatorTest {
+  private final TracerSdkProvider tracerSdkProvider = TracerSdkProvider.builder().build();
+  private final Tracer tracer = tracerSdkProvider.get("TracezDataAggregatorTest");
+  private static final String SPAN_NAME_ONE = "one";
+  private static final String SPAN_NAME_TWO = "two";
+
+  private TracezSpanProcessor spanProcessor;
+  private TracezDataAggregator dataAggregator;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    spanProcessor = TracezSpanProcessor.newBuilder().build();
+    tracerSdkProvider.addSpanProcessor(spanProcessor);
+    dataAggregator = new TracezDataAggregator(spanProcessor);
+  }
+
+  @Test
+  public void getRunningSpanCounts_twoSpanNames() {
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
+    /* getRunningSpanCounts should return a map with 2 different span names */
+    Map<String, Integer> counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(2);
+    assertThat(counts.get(SPAN_NAME_ONE)).isEqualTo(1);
+    assertThat(counts.get(SPAN_NAME_TWO)).isEqualTo(1);
+
+    span1.end();
+    /* getRunningSpanCounts should return a map with 1 unique span name */
+    counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(1);
+    assertThat(counts.get(SPAN_NAME_ONE)).isNull();
+    assertThat(counts.get(SPAN_NAME_TWO)).isEqualTo(1);
+
+    span2.end();
+    /* getRunningSpanCounts should return a map with no span names */
+    counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(0);
+    assertThat(counts.get(SPAN_NAME_ONE)).isNull();
+    assertThat(counts.get(SPAN_NAME_TWO)).isNull();
+  }
+
+  @Test
+  public void getRunningSpanCounts_oneSpanName() {
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span3 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    /* getRunningSpanCounts should return a map with 1 span name */
+    Map<String, Integer> counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(1);
+    assertThat(counts.get(SPAN_NAME_ONE)).isEqualTo(3);
+    span1.end();
+    span2.end();
+    span3.end();
+    /* getRunningSpanCounts should return a map with no span names */
+    counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(0);
+    assertThat(counts.get(SPAN_NAME_ONE)).isNull();
+  }
+
+  @Test
+  public void getRunningSpansByName_twoSpanNames() {
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
+    /* getRunningSpansByName should return a List with only the corresponding span */
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_ONE))
+        .containsExactly(((ReadableSpan) span1).toSpanData());
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_TWO))
+        .containsExactly(((ReadableSpan) span2).toSpanData());
+    span1.end();
+    span2.end();
+    /* getRunningSpansByName should return an empty List for each span name */
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_ONE).size()).isEqualTo(0);
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_TWO).size()).isEqualTo(0);
+  }
+
+  @Test
+  public void getRunningSpansByName_oneSpanName() {
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span3 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    /* getRunningSpansByName should return a List with all 3 spans */
+    List<SpanData> spans = dataAggregator.getRunningSpansByName(SPAN_NAME_ONE);
+    assertThat(spans.size()).isEqualTo(3);
+    assertThat(spans).contains(((ReadableSpan) span1).toSpanData());
+    assertThat(spans).contains(((ReadableSpan) span2).toSpanData());
+    assertThat(spans).contains(((ReadableSpan) span3).toSpanData());
+    span1.end();
+    span2.end();
+    span3.end();
+    /* getRunningSpansByName should return an empty List */
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_ONE).size()).isEqualTo(0);
+  }
+}

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
@@ -51,6 +51,15 @@ public final class TracezDataAggregatorTest {
   }
 
   @Test
+  public void getRunningSpanCounts_noSpans() {
+    /* getRunningSpanCounts should return a an empty map */
+    Map<String, Integer> counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(0);
+    assertThat(counts.get(SPAN_NAME_ONE)).isNull();
+    assertThat(counts.get(SPAN_NAME_TWO)).isNull();
+  }
+
+  @Test
   public void getRunningSpanCounts_twoSpanNames() {
     Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
     Span span2 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
@@ -91,6 +100,13 @@ public final class TracezDataAggregatorTest {
     counts = dataAggregator.getRunningSpanCounts();
     assertThat(counts.size()).isEqualTo(0);
     assertThat(counts.get(SPAN_NAME_ONE)).isNull();
+  }
+
+  @Test
+  public void getRunningSpansByName_noSpans() {
+    /* getRunningSpansByName should return an empty List */
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_ONE).size()).isEqualTo(0);
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_TWO).size()).isEqualTo(0);
   }
 
   @Test

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessorTest.java
@@ -34,9 +34,9 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-/** Unit tests for {@link TraceZSpanProcessor}. */
+/** Unit tests for {@link TracezSpanProcessor}. */
 @RunWith(JUnit4.class)
-public final class TraceZSpanProcessorTest {
+public final class TracezSpanProcessorTest {
   @Mock private ReadableSpan readableSpan;
   private static final SpanContext SAMPLED_SPAN_CONTEXT =
       SpanContext.create(
@@ -47,7 +47,7 @@ public final class TraceZSpanProcessorTest {
   private static final SpanContext NOT_SAMPLED_SPAN_CONTEXT = SpanContext.getInvalid();
 
   private static void assertSpanCacheSizes(
-      TraceZSpanProcessor spanProcessor, int runningSpanCacheSize, int completedSpanCacheSize) {
+      TracezSpanProcessor spanProcessor, int runningSpanCacheSize, int completedSpanCacheSize) {
     Collection<ReadableSpan> runningSpans = spanProcessor.getRunningSpans();
     Collection<ReadableSpan> completedSpans = spanProcessor.getCompletedSpans();
     assertThat(runningSpans.size()).isEqualTo(runningSpanCacheSize);
@@ -61,7 +61,7 @@ public final class TraceZSpanProcessorTest {
 
   @Test
   public void onStart_sampledSpan_inCache() {
-    TraceZSpanProcessor spanProcessor = TraceZSpanProcessor.newBuilder().build();
+    TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
     /* Return a sampled span, which should be added to the running cache by default */
     when(readableSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
     spanProcessor.onStart(readableSpan);
@@ -70,7 +70,7 @@ public final class TraceZSpanProcessorTest {
 
   @Test
   public void onEnd_sampledSpan_inCache() {
-    TraceZSpanProcessor spanProcessor = TraceZSpanProcessor.newBuilder().build();
+    TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
     /* Return a sampled span, which should be added to the completed cache upon ending */
     when(readableSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
     spanProcessor.onStart(readableSpan);
@@ -80,7 +80,7 @@ public final class TraceZSpanProcessorTest {
 
   @Test
   public void onStart_notSampledSpan_notInCache() {
-    TraceZSpanProcessor spanProcessor = TraceZSpanProcessor.newBuilder().build();
+    TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
     /* Return a non-sampled span, which should not be added to the running cache by default */
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     spanProcessor.onStart(readableSpan);
@@ -92,8 +92,8 @@ public final class TraceZSpanProcessorTest {
     /* Initialize a TraceZSpanProcessor that only looks at sampled spans */
     Properties properties = new Properties();
     properties.setProperty("otel.ssp.export.sampled", "true");
-    TraceZSpanProcessor spanProcessor =
-        TraceZSpanProcessor.newBuilder().readProperties(properties).build();
+    TracezSpanProcessor spanProcessor =
+        TracezSpanProcessor.newBuilder().readProperties(properties).build();
 
     /* Return a non-sampled span, which should not be added to the running cache */
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
@@ -106,8 +106,8 @@ public final class TraceZSpanProcessorTest {
     /* Initialize a TraceZSpanProcessor that looks at all spans */
     Properties properties = new Properties();
     properties.setProperty("otel.ssp.export.sampled", "false");
-    TraceZSpanProcessor spanProcessor =
-        TraceZSpanProcessor.newBuilder().readProperties(properties).build();
+    TracezSpanProcessor spanProcessor =
+        TracezSpanProcessor.newBuilder().readProperties(properties).build();
 
     /* Return a non-sampled span, which should be added to the caches */
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);


### PR DESCRIPTION
Modified TracezSpanProcessor and TracezSpanProcessorTest to adhere to the OpenCensus naming convention. Created TracezDataAggregator with aggregation logic for running spans. Unit tests included.