### PR TITLE
Modified SpanProcessor and DataAggregator to make implementing the frontend easier

### DIFF
--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TraceZDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TraceZDataAggregator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.zpages;
+
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A {@link SpanProcessor} implementation for the traceZ zPage.
+ *
+ * <p>Configuration options for {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor} can
+ * be read from system properties, environment variables, or {@link java.util.Properties} objects.
+ *
+ * <p>For system properties and {@link java.util.Properties} objects, {@link
+ * io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor} will look for the following names:
+ *
+ * <ul>
+ *   <li>{@code otel.ssp.export.sampled}: sets whether only sampled spans should be exported.
+ * </ul>
+ *
+ * <p>For environment variables, {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}
+ * will look for the following names:
+ *
+ * <ul>
+ *   <li>{@code OTEL_SSP_EXPORT_SAMPLED}: sets whether only sampled spans should be exported.
+ * </ul>
+ */
+@ThreadSafe
+public final class TraceZDataAggregator {
+  private final TraceZSpanProcessor spanProcessor;
+
+  /**
+   * Constructor for {@link io.opentelemetry.sdk.contrib.zpages.TraceZDataAggregator}.
+   *
+   * @param spanProcessor collects span data.
+   */
+  public TraceZDataAggregator(TraceZSpanProcessor spanProcessor) {
+    this.spanProcessor = spanProcessor;
+  }
+
+  /**
+   * Returns a Collection of all running spans for {@link
+   * io.opentelemetry.sdk.contrib.zpages.TraceZDataAggregator}.
+   *
+   * @param spanName name to filter returned spans.
+   * @return a List of {@link io.opentelemetry.sdk.trace.data.SpanData}.\
+   */
+  public List<SpanData> getRunningSpansByName(String spanName) {
+    Collection<ReadableSpan> allRunningSpans = spanProcessor.getRunningSpans();
+    List<SpanData> runningSpanData = new ArrayList<>();
+    for (ReadableSpan span : allRunningSpans) {
+      if (span.getName().equals(spanName)) {
+        runningSpanData.add(span.toSpanData());
+      }
+    }
+    return runningSpanData;
+  }
+}

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -193,7 +193,7 @@ public final class TracezDataAggregator {
    * Returns a nested Map of counts for all {@link io.opentelemetry.trace.Status#OK} spans in {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
-   * @return a Map of spam-count Maps indexed by latency boundaries for each span name.
+   * @return a Map of span-count Maps indexed by latency boundaries for each span name.
    */
   public Map<String, Map<LatencyBoundaries, Integer>> getSpanLatencyCounts() {
     Map<String, Map<LatencyBoundaries, Integer>> numSpansPerName = new HashMap<>();

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -190,7 +190,8 @@ public final class TracezDataAggregator {
   }
 
   /**
-   * Returns a nested Map of counts indexed by latency boundaries for all {@link io.opentelemetry.trace.Status#OK} spans in {@link
+   * Returns a nested Map of counts indexed by latency boundaries for all {@link
+   * io.opentelemetry.trace.Status#OK} spans in {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
    * @return a Map of spam-count Maps for each span name.
@@ -198,9 +199,12 @@ public final class TracezDataAggregator {
   public Map<String, Map<LatencyBoundaries, Integer>> getSpanLatencyCounts() {
     Map<String, Map<LatencyBoundaries, Integer>> numSpansPerName = new HashMap<>();
     for (LatencyBoundaries bucket : LatencyBoundaries.values()) {
-      for (Map.Entry<String, Integer> entry : getSpanLatencyCounts(bucket.getLatencyLowerBound(), bucket.getLatencyUpperBound()).entrySet()) {
+      for (Map.Entry<String, Integer> entry :
+          getSpanLatencyCounts(bucket.getLatencyLowerBound(), bucket.getLatencyUpperBound())
+              .entrySet()) {
         if (!numSpansPerName.containsKey(entry.getKey())) {
-          numSpansPerName.put(entry.getKey(), new EnumMap<LatencyBoundaries, Integer>(LatencyBoundaries.class));
+          numSpansPerName.put(
+              entry.getKey(), new EnumMap<LatencyBoundaries, Integer>(LatencyBoundaries.class));
         }
         numSpansPerName.get(entry.getKey()).put(bucket, entry.getValue());
       }

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -127,7 +127,7 @@ public final class TracezDataAggregator {
      *
      * @return the latency lower bound of the bucket.
      */
-    private long getLatencyLowerBound() {
+    public long getLatencyLowerBound() {
       return latencyLowerBound;
     }
 
@@ -136,7 +136,7 @@ public final class TracezDataAggregator {
      *
      * @return the latency upper bound of the bucket.
      */
-    private long getLatencyUpperBound() {
+    public long getLatencyUpperBound() {
       return latencyUpperBound;
     }
   }

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -142,8 +142,8 @@ public final class TracezDataAggregator {
   }
 
   /**
-   * Returns a Map of counts for the completed spans within [lowerBound, upperBound) {@link
-   * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
+   * Returns a Map of counts for the {@link io.opentelemetry.trace.Status#OK} spans within
+   * [lowerBound, upperBound) {@link io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
    * @param lowerBound latency lower bound (inclusive)
    * @param upperBound latency upper bound (exclusive)
@@ -164,7 +164,7 @@ public final class TracezDataAggregator {
   }
 
   /**
-   * Returns a nested Map of counts for all completed spans {@link
+   * Returns a nested Map of counts for all {@link io.opentelemetry.trace.Status#OK} spans {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
    * @return a Map of span-count Maps for each latency boundary.
@@ -181,8 +181,9 @@ public final class TracezDataAggregator {
   }
 
   /**
-   * Returns a List of all completed spans with a given span name between [lowerBound, upperBound)
-   * for {@link io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
+   * Returns a List of all {@link io.opentelemetry.trace.Status#OK} spans with a given span name
+   * between [lowerBound, upperBound) for {@link
+   * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
    * @param spanName name to filter returned spans.
    * @param lowerBound latency lower bound (inclusive)

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -49,10 +49,10 @@ public final class TracezDataAggregator {
   }
 
   /**
-   * Returns a List of all span names for {@link
+   * Returns a Set of running and completed span names for {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
-   * @return a List of {@link String}.
+   * @return a Set of {@link String}.
    */
   public Set<String> getSpanNames() {
     Set<String> spanNames = new TreeSet<>();
@@ -190,11 +190,10 @@ public final class TracezDataAggregator {
   }
 
   /**
-   * Returns a nested Map of counts indexed by latency boundaries for all {@link
-   * io.opentelemetry.trace.Status#OK} spans in {@link
+   * Returns a nested Map of counts for all {@link io.opentelemetry.trace.Status#OK} spans in {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
-   * @return a Map of spam-count Maps for each span name.
+   * @return a Map of spam-count Maps indexed by latency boundaries for each span name.
    */
   public Map<String, Map<LatencyBoundaries, Integer>> getSpanLatencyCounts() {
     Map<String, Map<LatencyBoundaries, Integer>> numSpansPerName = new HashMap<>();

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -25,41 +25,27 @@ import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * A {@link SpanProcessor} implementation for the traceZ zPage.
+ * A data aggregator for the traceZ zPage.
  *
- * <p>Configuration options for {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor} can
- * be read from system properties, environment variables, or {@link java.util.Properties} objects.
- *
- * <p>For system properties and {@link java.util.Properties} objects, {@link
- * io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor} will look for the following names:
- *
- * <ul>
- *   <li>{@code otel.ssp.export.sampled}: sets whether only sampled spans should be exported.
- * </ul>
- *
- * <p>For environment variables, {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}
- * will look for the following names:
- *
- * <ul>
- *   <li>{@code OTEL_SSP_EXPORT_SAMPLED}: sets whether only sampled spans should be exported.
- * </ul>
+ * <p>The traceZ data aggregator complies information about the running spans, span latencies, and
+ * error spans for the frontend of the zPage.
  */
 @ThreadSafe
-public final class TraceZDataAggregator {
-  private final TraceZSpanProcessor spanProcessor;
+public final class TracezDataAggregator {
+  private final TracezSpanProcessor spanProcessor;
 
   /**
-   * Constructor for {@link io.opentelemetry.sdk.contrib.zpages.TraceZDataAggregator}.
+   * Constructor for {@link io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
    * @param spanProcessor collects span data.
    */
-  public TraceZDataAggregator(TraceZSpanProcessor spanProcessor) {
+  public TracezDataAggregator(TracezSpanProcessor spanProcessor) {
     this.spanProcessor = spanProcessor;
   }
 
   /**
-   * Returns a Collection of all running spans for {@link
-   * io.opentelemetry.sdk.contrib.zpages.TraceZDataAggregator}.
+   * Returns a List of all running spans for {@link
+   * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
    * @param spanName name to filter returned spans.
    * @return a List of {@link io.opentelemetry.sdk.trace.data.SpanData}.\

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -80,6 +80,11 @@ public final class TracezDataAggregator {
     return filteredSpans;
   }
 
+  /**
+   * A class of boundaries for the latency buckets. The completed spans with a status of {@link
+   * io.opentelemetry.trace.Status#OK} are categorized into one of these buckets om the traceZ
+   * zPage.
+   */
   public enum LatencyBoundaries {
     /** Stores finished successful requests of duration within the interval [0, 10us). */
     ZERO_MICROSx10(0, TimeUnit.MICROSECONDS.toNanos(10)),

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -20,9 +20,11 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -72,6 +74,127 @@ public final class TracezDataAggregator {
     List<SpanData> filteredSpans = new ArrayList<>();
     for (ReadableSpan span : allRunningSpans) {
       if (span.getName().equals(spanName)) {
+        filteredSpans.add(span.toSpanData());
+      }
+    }
+    return filteredSpans;
+  }
+
+  public enum LatencyBoundaries {
+    /** Stores finished successful requests of duration within the interval [0, 10us). */
+    ZERO_MICROSx10(0, TimeUnit.MICROSECONDS.toNanos(10)),
+
+    /** Stores finished successful requests of duration within the interval [10us, 100us). */
+    MICROSx10_MICROSx100(TimeUnit.MICROSECONDS.toNanos(10), TimeUnit.MICROSECONDS.toNanos(100)),
+
+    /** Stores finished successful requests of duration within the interval [100us, 1ms). */
+    MICROSx100_MILLIx1(TimeUnit.MICROSECONDS.toNanos(100), TimeUnit.MILLISECONDS.toNanos(1)),
+
+    /** Stores finished successful requests of duration within the interval [1ms, 10ms). */
+    MILLIx1_MILLIx10(TimeUnit.MILLISECONDS.toNanos(1), TimeUnit.MILLISECONDS.toNanos(10)),
+
+    /** Stores finished successful requests of duration within the interval [10ms, 100ms). */
+    MILLIx10_MILLIx100(TimeUnit.MILLISECONDS.toNanos(10), TimeUnit.MILLISECONDS.toNanos(100)),
+
+    /** Stores finished successful requests of duration within the interval [100ms, 1sec). */
+    MILLIx100_SECONDx1(TimeUnit.MILLISECONDS.toNanos(100), TimeUnit.SECONDS.toNanos(1)),
+
+    /** Stores finished successful requests of duration within the interval [1sec, 10sec). */
+    SECONDx1_SECONDx10(TimeUnit.SECONDS.toNanos(1), TimeUnit.SECONDS.toNanos(10)),
+
+    /** Stores finished successful requests of duration within the interval [10sec, 100sec). */
+    SECONDx10_SECONDx100(TimeUnit.SECONDS.toNanos(10), TimeUnit.SECONDS.toNanos(100)),
+
+    /** Stores finished successful requests of duration greater than or equal to 100sec. */
+    SECONDx100_MAX(TimeUnit.SECONDS.toNanos(100), Long.MAX_VALUE);
+
+    private final long latencyLowerBound;
+    private final long latencyUpperBound;
+
+    /**
+     * Constructs a {@code LatencyBoundaries} with the given boundaries and label.
+     *
+     * @param latencyLowerBound the latency lower bound of the bucket.
+     * @param latencyUpperBound the latency upper bound of the bucket.
+     */
+    LatencyBoundaries(long latencyLowerBound, long latencyUpperBound) {
+      this.latencyLowerBound = latencyLowerBound;
+      this.latencyUpperBound = latencyUpperBound;
+    }
+
+    /**
+     * Returns the latency lower bound of the bucket.
+     *
+     * @return the latency lower bound of the bucket.
+     */
+    private long getLatencyLowerBound() {
+      return latencyLowerBound;
+    }
+
+    /**
+     * Returns the latency upper bound of the bucket.
+     *
+     * @return the latency upper bound of the bucket.
+     */
+    private long getLatencyUpperBound() {
+      return latencyUpperBound;
+    }
+  }
+
+  /**
+   * Returns a Map of counts for the completed spans within [lowerBound, upperBound) {@link
+   * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
+   *
+   * @param lowerBound latency lower bound (inclusive)
+   * @param upperBound latency upper bound (exclusive)
+   * @return a Map of span counts for each span name within the bounds.
+   */
+  public Map<String, Integer> getSpanLatencyCounts(long lowerBound, long upperBound) {
+    Collection<ReadableSpan> allCompletedSpans = spanProcessor.getCompletedSpans();
+    Map<String, Integer> numSpansPerName = new HashMap<>();
+    for (ReadableSpan span : allCompletedSpans) {
+      if (span.getLatencyNanos() >= lowerBound && span.getLatencyNanos() < upperBound) {
+        Integer prevValue = numSpansPerName.get(span.getName());
+        numSpansPerName.put(span.getName(), prevValue != null ? prevValue + 1 : 1);
+      }
+    }
+    return numSpansPerName;
+  }
+
+  /**
+   * Returns a nested Map of counts for all completed spans {@link
+   * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
+   *
+   * @return a Map of span-count Maps for each latency boundary.
+   */
+  public Map<LatencyBoundaries, Map<String, Integer>> getSpanLatencyCounts() {
+    Map<LatencyBoundaries, Map<String, Integer>> numSpansPerBoundary =
+        new EnumMap<>(LatencyBoundaries.class);
+    for (LatencyBoundaries bucket : LatencyBoundaries.values()) {
+      numSpansPerBoundary.put(
+          bucket,
+          getSpanLatencyCounts(bucket.getLatencyLowerBound(), bucket.getLatencyUpperBound()));
+    }
+    return numSpansPerBoundary;
+  }
+
+  /**
+   * Returns a List of all completed spans with a given span name between [lowerBound, upperBound)
+   * for {@link io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
+   *
+   * @param spanName name to filter returned spans.
+   * @param lowerBound latency lower bound (inclusive)
+   * @param upperBound latency upper bound (exclusive)
+   * @return a List of {@link io.opentelemetry.sdk.trace.data.SpanData}.
+   */
+  public List<SpanData> getCompletedSpansByLatency(
+      String spanName, long lowerBound, long upperBound) {
+    Collection<ReadableSpan> allCompletedSpans = spanProcessor.getCompletedSpans();
+    List<SpanData> filteredSpans = new ArrayList<>();
+    for (ReadableSpan span : allCompletedSpans) {
+      if (span.getName().equals(spanName)
+          && span.getLatencyNanos() >= lowerBound
+          && span.getLatencyNanos() < upperBound) {
         filteredSpans.add(span.toSpanData());
       }
     }

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -69,7 +69,7 @@ public final class TracezDataAggregator {
    * @param spanName name to filter returned spans.
    * @return a List of {@link io.opentelemetry.sdk.trace.data.SpanData}.
    */
-  public List<SpanData> getRunningSpansByName(String spanName) {
+  public List<SpanData> getRunningSpans(String spanName) {
     Collection<ReadableSpan> allRunningSpans = spanProcessor.getRunningSpans();
     List<SpanData> filteredSpans = new ArrayList<>();
     for (ReadableSpan span : allRunningSpans) {
@@ -153,7 +153,9 @@ public final class TracezDataAggregator {
     Collection<ReadableSpan> allCompletedSpans = spanProcessor.getCompletedSpans();
     Map<String, Integer> numSpansPerName = new HashMap<>();
     for (ReadableSpan span : allCompletedSpans) {
-      if (span.getLatencyNanos() >= lowerBound && span.getLatencyNanos() < upperBound) {
+      if (span.toSpanData().getStatus().isOk()
+          && span.getLatencyNanos() >= lowerBound
+          && span.getLatencyNanos() < upperBound) {
         Integer prevValue = numSpansPerName.get(span.getName());
         numSpansPerName.put(span.getName(), prevValue != null ? prevValue + 1 : 1);
       }
@@ -187,12 +189,12 @@ public final class TracezDataAggregator {
    * @param upperBound latency upper bound (exclusive)
    * @return a List of {@link io.opentelemetry.sdk.trace.data.SpanData}.
    */
-  public List<SpanData> getCompletedSpansByLatency(
-      String spanName, long lowerBound, long upperBound) {
+  public List<SpanData> getOkSpans(String spanName, long lowerBound, long upperBound) {
     Collection<ReadableSpan> allCompletedSpans = spanProcessor.getCompletedSpans();
     List<SpanData> filteredSpans = new ArrayList<>();
     for (ReadableSpan span : allCompletedSpans) {
-      if (span.getName().equals(spanName)
+      if (span.toSpanData().getStatus().isOk()
+          && span.getName().equals(spanName)
           && span.getLatencyNanos() >= lowerBound
           && span.getLatencyNanos() < upperBound) {
         filteredSpans.add(span.toSpanData());

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -17,11 +17,12 @@
 package io.opentelemetry.sdk.contrib.zpages;
 
 import io.opentelemetry.sdk.trace.ReadableSpan;
-import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -44,7 +45,23 @@ public final class TracezDataAggregator {
   }
 
   /**
-   * Returns a List of all running spans for {@link
+   * Returns a Map of the running span counts for {@link
+   * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
+   *
+   * @return a Map of span counts for each span name.\
+   */
+  public Map<String, Integer> getRunningSpanCounts() {
+    Collection<ReadableSpan> allRunningSpans = spanProcessor.getRunningSpans();
+    Map<String, Integer> numSpansPerName = new HashMap<>();
+    for (ReadableSpan span : allRunningSpans) {
+      Integer prevValue = numSpansPerName.get(span.getName());
+      numSpansPerName.put(span.getName(), prevValue != null ? prevValue + 1 : 1);
+    }
+    return numSpansPerName;
+  }
+
+  /**
+   * Returns a List of all running spans with a given span name for {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
    * @param spanName name to filter returned spans.

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -190,22 +190,24 @@ public final class TracezDataAggregator {
   }
 
   /**
-   * Returns a nested Map of counts for all {@link io.opentelemetry.trace.Status#OK} spans in {@link
-   * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
+   * Returns a Map of span names to counts for all {@link io.opentelemetry.trace.Status#OK} spans in
+   * {@link io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
-   * @return a Map of span-count Maps indexed by latency boundaries for each span name.
+   * @return a Map of span names to counts, where the counts are further indexed by the latency
+   *     boundaries.
    */
   public Map<String, Map<LatencyBoundaries, Integer>> getSpanLatencyCounts() {
     Map<String, Map<LatencyBoundaries, Integer>> numSpansPerName = new HashMap<>();
     for (LatencyBoundaries bucket : LatencyBoundaries.values()) {
-      for (Map.Entry<String, Integer> entry :
-          getSpanLatencyCounts(bucket.getLatencyLowerBound(), bucket.getLatencyUpperBound())
-              .entrySet()) {
-        if (!numSpansPerName.containsKey(entry.getKey())) {
+      Map<String, Integer> latencyCounts =
+          getSpanLatencyCounts(bucket.getLatencyLowerBound(), bucket.getLatencyUpperBound());
+      for (Map.Entry<String, Integer> spanNameToCount : latencyCounts.entrySet()) {
+        if (!numSpansPerName.containsKey(spanNameToCount.getKey())) {
           numSpansPerName.put(
-              entry.getKey(), new EnumMap<LatencyBoundaries, Integer>(LatencyBoundaries.class));
+              spanNameToCount.getKey(),
+              new EnumMap<LatencyBoundaries, Integer>(LatencyBoundaries.class));
         }
-        numSpansPerName.get(entry.getKey()).put(bucket, entry.getValue());
+        numSpansPerName.get(spanNameToCount.getKey()).put(bucket, spanNameToCount.getValue());
       }
     }
     return numSpansPerName;

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregator.java
@@ -28,7 +28,7 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * A data aggregator for the traceZ zPage.
  *
- * <p>The traceZ data aggregator complies information about the running spans, span latencies, and
+ * <p>The traceZ data aggregator compiles information about the running spans, span latencies, and
  * error spans for the frontend of the zPage.
  */
 @ThreadSafe
@@ -48,7 +48,7 @@ public final class TracezDataAggregator {
    * Returns a Map of the running span counts for {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
-   * @return a Map of span counts for each span name.\
+   * @return a Map of span counts for each span name.
    */
   public Map<String, Integer> getRunningSpanCounts() {
     Collection<ReadableSpan> allRunningSpans = spanProcessor.getRunningSpans();
@@ -65,16 +65,16 @@ public final class TracezDataAggregator {
    * io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator}.
    *
    * @param spanName name to filter returned spans.
-   * @return a List of {@link io.opentelemetry.sdk.trace.data.SpanData}.\
+   * @return a List of {@link io.opentelemetry.sdk.trace.data.SpanData}.
    */
   public List<SpanData> getRunningSpansByName(String spanName) {
     Collection<ReadableSpan> allRunningSpans = spanProcessor.getRunningSpans();
-    List<SpanData> runningSpanData = new ArrayList<>();
+    List<SpanData> filteredSpans = new ArrayList<>();
     for (ReadableSpan span : allRunningSpans) {
       if (span.getName().equals(spanName)) {
-        runningSpanData.add(span.toSpanData());
+        filteredSpans.add(span.toSpanData());
       }
     }
-    return runningSpanData;
+    return filteredSpans;
   }
 }

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessor.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessor.java
@@ -109,7 +109,7 @@ public final class TracezSpanProcessor implements SpanProcessor {
    * Returns a Collection of all running spans for {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
-   * @return a Collection of {@link io.opentelemetry.sdk.trace.ReadableSpan}.\
+   * @return a Collection of {@link io.opentelemetry.sdk.trace.ReadableSpan}.
    */
   public Collection<ReadableSpan> getRunningSpans() {
     synchronized (this) {
@@ -121,7 +121,7 @@ public final class TracezSpanProcessor implements SpanProcessor {
    * Returns a Collection of all completed spans for {@link
    * io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
-   * @return a Collection of {@link io.opentelemetry.sdk.trace.ReadableSpan}.\
+   * @return a Collection of {@link io.opentelemetry.sdk.trace.ReadableSpan}.
    */
   public Collection<ReadableSpan> getCompletedSpans() {
     synchronized (this) {
@@ -132,7 +132,7 @@ public final class TracezSpanProcessor implements SpanProcessor {
   /**
    * Returns a new Builder for {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
-   * @return a new {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.\
+   * @return a new {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    */
   public static Builder newBuilder() {
     return new Builder();

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessor.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessor.java
@@ -65,9 +65,6 @@ public final class TracezSpanProcessor implements SpanProcessor {
 
   @Override
   public void onStart(ReadableSpan span) {
-    if (sampled && !span.getSpanContext().getTraceFlags().isSampled()) {
-      return;
-    }
     synchronized (this) {
       runningSpanCache.put(span.getSpanContext().getSpanId(), span);
     }
@@ -80,13 +77,12 @@ public final class TracezSpanProcessor implements SpanProcessor {
 
   @Override
   public void onEnd(ReadableSpan span) {
-    if (sampled && !span.getSpanContext().getTraceFlags().isSampled()) {
-      return;
-    }
+    SpanId id = span.getSpanContext().getSpanId();
     synchronized (this) {
-      SpanId id = span.getSpanContext().getSpanId();
       runningSpanCache.remove(id);
-      completedSpanCache.put(id, span);
+      if (!sampled || span.getSpanContext().getTraceFlags().isSampled()) {
+        completedSpanCache.put(id, span);
+      }
     }
   }
 

--- a/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessor.java
+++ b/sdk_contrib/zpages/src/main/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessor.java
@@ -29,17 +29,17 @@ import javax.annotation.concurrent.ThreadSafe;
 /**
  * A {@link SpanProcessor} implementation for the traceZ zPage.
  *
- * <p>Configuration options for {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor} can
+ * <p>Configuration options for {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor} can
  * be read from system properties, environment variables, or {@link java.util.Properties} objects.
  *
  * <p>For system properties and {@link java.util.Properties} objects, {@link
- * io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor} will look for the following names:
+ * io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor} will look for the following names:
  *
  * <ul>
  *   <li>{@code otel.ssp.export.sampled}: sets whether only sampled spans should be exported.
  * </ul>
  *
- * <p>For environment variables, {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}
+ * <p>For environment variables, {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}
  * will look for the following names:
  *
  * <ul>
@@ -47,17 +47,17 @@ import javax.annotation.concurrent.ThreadSafe;
  * </ul>
  */
 @ThreadSafe
-public final class TraceZSpanProcessor implements SpanProcessor {
+public final class TracezSpanProcessor implements SpanProcessor {
   private final Map<SpanId, ReadableSpan> runningSpanCache;
   private final Map<SpanId, ReadableSpan> completedSpanCache;
   private final boolean sampled;
 
   /**
-   * Constructor for {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.
+   * Constructor for {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
    * @param sampled report only sampled spans.
    */
-  public TraceZSpanProcessor(boolean sampled) {
+  public TracezSpanProcessor(boolean sampled) {
     runningSpanCache = new HashMap<>();
     completedSpanCache = new HashMap<>();
     this.sampled = sampled;
@@ -107,7 +107,7 @@ public final class TraceZSpanProcessor implements SpanProcessor {
 
   /**
    * Returns a Collection of all running spans for {@link
-   * io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.
+   * io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
    * @return a Collection of {@link io.opentelemetry.sdk.trace.ReadableSpan}.\
    */
@@ -119,7 +119,7 @@ public final class TraceZSpanProcessor implements SpanProcessor {
 
   /**
    * Returns a Collection of all completed spans for {@link
-   * io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.
+   * io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
    * @return a Collection of {@link io.opentelemetry.sdk.trace.ReadableSpan}.\
    */
@@ -130,15 +130,15 @@ public final class TraceZSpanProcessor implements SpanProcessor {
   }
 
   /**
-   * Returns a new Builder for {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.
+   * Returns a new Builder for {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
    *
-   * @return a new {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.\
+   * @return a new {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.\
    */
   public static Builder newBuilder() {
     return new Builder();
   }
 
-  /** Builder class for {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}. */
+  /** Builder class for {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}. */
   public static final class Builder extends ConfigBuilder<Builder> {
 
     private static final String KEY_SAMPLED = "otel.ssp.export.sampled";
@@ -185,12 +185,12 @@ public final class TraceZSpanProcessor implements SpanProcessor {
     }
 
     /**
-     * Returns a new {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.
+     * Returns a new {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
      *
-     * @return a new {@link io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor}.
+     * @return a new {@link io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor}.
      */
-    public io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor build() {
-      return new io.opentelemetry.sdk.contrib.zpages.TraceZSpanProcessor(sampled);
+    public io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor build() {
+      return new io.opentelemetry.sdk.contrib.zpages.TracezSpanProcessor(sampled);
     }
   }
 }

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
@@ -53,16 +53,19 @@ public final class TracezDataAggregatorTest {
   }
 
   @Test
-  public void getSpanNames_twoUniqueNames() {
+  public void getSpanNames_noSpans() {
     /* getSpanNames should return a an empty set initially */
     Set<String> names = dataAggregator.getSpanNames();
     assertThat(names.size()).isEqualTo(0);
+  }
 
+  @Test
+  public void getSpanNames_twoSpanNames() {
     /* getSpanNames should return a set with 2 span names */
     Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
     Span span2 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
     Span span3 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
-    names = dataAggregator.getSpanNames();
+    Set<String> names = dataAggregator.getSpanNames();
     assertThat(names.size()).isEqualTo(2);
     assertThat(names).contains(SPAN_NAME_ONE);
     assertThat(names).contains(SPAN_NAME_TWO);

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
@@ -27,6 +27,7 @@ import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,6 +50,31 @@ public final class TracezDataAggregatorTest {
   public void setup() {
     MockitoAnnotations.initMocks(this);
     tracerSdkProvider.addSpanProcessor(spanProcessor);
+  }
+
+  @Test
+  public void getSpanNames_twoNames() {
+    /* getSpanNames should return a an empty set initially */
+    Set<String> names = dataAggregator.getSpanNames();
+    assertThat(names.size()).isEqualTo(0);
+
+    /* getSpanNames should return a set with 2 span names */
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
+    Span span3 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
+    names = dataAggregator.getSpanNames();
+    assertThat(names.size()).isEqualTo(2);
+    assertThat(names).contains(SPAN_NAME_ONE);
+    assertThat(names).contains(SPAN_NAME_TWO);
+
+    /* getSpanNames should still return a set with 2 span names */
+    span1.end();
+    span2.end();
+    span3.end();
+    names = dataAggregator.getSpanNames();
+    assertThat(names.size()).isEqualTo(2);
+    assertThat(names).contains(SPAN_NAME_ONE);
+    assertThat(names).contains(SPAN_NAME_TWO);
   }
 
   @Test
@@ -161,14 +187,17 @@ public final class TracezDataAggregatorTest {
       span.end();
     }
     /* getSpanLatencyCounts should return 1 span per latency bucket */
-    Map<LatencyBoundaries, Map<String, Integer>> allCounts = dataAggregator.getSpanLatencyCounts();
+    Map<String, Map<LatencyBoundaries, Integer>> allCounts = dataAggregator.getSpanLatencyCounts();
     for (LatencyBoundaries bucket : LatencyBoundaries.values()) {
       Map<String, Integer> counts =
           dataAggregator.getSpanLatencyCounts(
               bucket.getLatencyLowerBound(), bucket.getLatencyUpperBound());
       assertThat(counts.size()).isEqualTo(1);
       assertThat(counts.get(SPAN_NAME_ONE)).isEqualTo(1);
-      assertThat(counts.entrySet()).isEqualTo(allCounts.get(bucket).entrySet());
+      for (Map.Entry<String, Integer> countsEntry : counts.entrySet()) {
+        assertThat(countsEntry.getValue())
+            .isEqualTo(allCounts.get(countsEntry.getKey()).get(bucket));
+      }
     }
   }
 

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
@@ -103,35 +103,35 @@ public final class TracezDataAggregatorTest {
   }
 
   @Test
-  public void getRunningSpansByName_noSpans() {
-    /* getRunningSpansByName should return an empty List */
-    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_ONE).size()).isEqualTo(0);
-    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_TWO).size()).isEqualTo(0);
+  public void getRunningSpans_noSpans() {
+    /* getRunningSpans should return an empty List */
+    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_ONE).size()).isEqualTo(0);
+    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_TWO).size()).isEqualTo(0);
   }
 
   @Test
-  public void getRunningSpansByName_twoSpanNames() {
+  public void getRunningSpans_twoSpanNames() {
     Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
     Span span2 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
-    /* getRunningSpansByName should return a List with only the corresponding span */
-    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_ONE))
+    /* getRunningSpans should return a List with only the corresponding span */
+    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_ONE))
         .containsExactly(((ReadableSpan) span1).toSpanData());
-    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_TWO))
+    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_TWO))
         .containsExactly(((ReadableSpan) span2).toSpanData());
     span1.end();
     span2.end();
-    /* getRunningSpansByName should return an empty List for each span name */
-    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_ONE).size()).isEqualTo(0);
-    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_TWO).size()).isEqualTo(0);
+    /* getRunningSpans should return an empty List for each span name */
+    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_ONE).size()).isEqualTo(0);
+    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_TWO).size()).isEqualTo(0);
   }
 
   @Test
-  public void getRunningSpansByName_oneSpanName() {
+  public void getRunningSpans_oneSpanName() {
     Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
     Span span2 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
     Span span3 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
-    /* getRunningSpansByName should return a List with all 3 spans */
-    List<SpanData> spans = dataAggregator.getRunningSpansByName(SPAN_NAME_ONE);
+    /* getRunningSpans should return a List with all 3 spans */
+    List<SpanData> spans = dataAggregator.getRunningSpans(SPAN_NAME_ONE);
     assertThat(spans.size()).isEqualTo(3);
     assertThat(spans).contains(((ReadableSpan) span1).toSpanData());
     assertThat(spans).contains(((ReadableSpan) span2).toSpanData());
@@ -139,7 +139,7 @@ public final class TracezDataAggregatorTest {
     span1.end();
     span2.end();
     span3.end();
-    /* getRunningSpansByName should return an empty List */
-    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_ONE).size()).isEqualTo(0);
+    /* getRunningSpans should return an empty List */
+    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_ONE).size()).isEqualTo(0);
   }
 }

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.sdk.contrib.zpages;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.TracerSdkProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.trace.Span;
+import io.opentelemetry.trace.Tracer;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.MockitoAnnotations;
+
+/** Unit tests for {@link TracezDataAggregator}. */
+@RunWith(JUnit4.class)
+public final class TracezDataAggregatorTest {
+  private final TracerSdkProvider tracerSdkProvider = TracerSdkProvider.builder().build();
+  private final Tracer tracer = tracerSdkProvider.get("TracezDataAggregatorTest");
+  private static final String SPAN_NAME_ONE = "one";
+  private static final String SPAN_NAME_TWO = "two";
+
+  private TracezSpanProcessor spanProcessor;
+  private TracezDataAggregator dataAggregator;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    spanProcessor = TracezSpanProcessor.newBuilder().build();
+    tracerSdkProvider.addSpanProcessor(spanProcessor);
+    dataAggregator = new TracezDataAggregator(spanProcessor);
+  }
+
+  @Test
+  public void getRunningSpanCounts_twoSpanNames() {
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
+    /* getRunningSpanCounts should return a map with 2 different span names */
+    Map<String, Integer> counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(2);
+    assertThat(counts.get(SPAN_NAME_ONE)).isEqualTo(1);
+    assertThat(counts.get(SPAN_NAME_TWO)).isEqualTo(1);
+
+    span1.end();
+    /* getRunningSpanCounts should return a map with 1 unique span name */
+    counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(1);
+    assertThat(counts.get(SPAN_NAME_ONE)).isNull();
+    assertThat(counts.get(SPAN_NAME_TWO)).isEqualTo(1);
+
+    span2.end();
+    /* getRunningSpanCounts should return a map with no span names */
+    counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(0);
+    assertThat(counts.get(SPAN_NAME_ONE)).isNull();
+    assertThat(counts.get(SPAN_NAME_TWO)).isNull();
+  }
+
+  @Test
+  public void getRunningSpanCounts_oneSpanName() {
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span3 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    /* getRunningSpanCounts should return a map with 1 span name */
+    Map<String, Integer> counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(1);
+    assertThat(counts.get(SPAN_NAME_ONE)).isEqualTo(3);
+    span1.end();
+    span2.end();
+    span3.end();
+    /* getRunningSpanCounts should return a map with no span names */
+    counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(0);
+    assertThat(counts.get(SPAN_NAME_ONE)).isNull();
+  }
+
+  @Test
+  public void getRunningSpansByName_twoSpanNames() {
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
+    /* getRunningSpansByName should return a List with only the corresponding span */
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_ONE))
+        .containsExactly(((ReadableSpan) span1).toSpanData());
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_TWO))
+        .containsExactly(((ReadableSpan) span2).toSpanData());
+    span1.end();
+    span2.end();
+    /* getRunningSpansByName should return an empty List for each span name */
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_ONE).size()).isEqualTo(0);
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_TWO).size()).isEqualTo(0);
+  }
+
+  @Test
+  public void getRunningSpansByName_oneSpanName() {
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span3 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    /* getRunningSpansByName should return a List with all 3 spans */
+    List<SpanData> spans = dataAggregator.getRunningSpansByName(SPAN_NAME_ONE);
+    assertThat(spans.size()).isEqualTo(3);
+    assertThat(spans).contains(((ReadableSpan) span1).toSpanData());
+    assertThat(spans).contains(((ReadableSpan) span2).toSpanData());
+    assertThat(spans).contains(((ReadableSpan) span3).toSpanData());
+    span1.end();
+    span2.end();
+    span3.end();
+    /* getRunningSpansByName should return an empty List */
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_ONE).size()).isEqualTo(0);
+  }
+}

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
@@ -53,7 +53,7 @@ public final class TracezDataAggregatorTest {
   }
 
   @Test
-  public void getSpanNames_twoNames() {
+  public void getSpanNames_twoUniqueNames() {
     /* getSpanNames should return a an empty set initially */
     Set<String> names = dataAggregator.getSpanNames();
     assertThat(names.size()).isEqualTo(0);

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
@@ -51,6 +51,15 @@ public final class TracezDataAggregatorTest {
   }
 
   @Test
+  public void getRunningSpanCounts_noSpans() {
+    /* getRunningSpanCounts should return a an empty map */
+    Map<String, Integer> counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(0);
+    assertThat(counts.get(SPAN_NAME_ONE)).isNull();
+    assertThat(counts.get(SPAN_NAME_TWO)).isNull();
+  }
+
+  @Test
   public void getRunningSpanCounts_twoSpanNames() {
     Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
     Span span2 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
@@ -91,6 +100,13 @@ public final class TracezDataAggregatorTest {
     counts = dataAggregator.getRunningSpanCounts();
     assertThat(counts.size()).isEqualTo(0);
     assertThat(counts.get(SPAN_NAME_ONE)).isNull();
+  }
+
+  @Test
+  public void getRunningSpansByName_noSpans() {
+    /* getRunningSpansByName should return an empty List */
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_ONE).size()).isEqualTo(0);
+    assertThat(dataAggregator.getRunningSpansByName(SPAN_NAME_TWO).size()).isEqualTo(0);
   }
 
   @Test

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
@@ -18,6 +18,8 @@ package io.opentelemetry.sdk.contrib.zpages;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opentelemetry.sdk.contrib.zpages.TracezDataAggregator.LatencyBoundaries;
+import io.opentelemetry.sdk.internal.TestClock;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.TracerSdkProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -34,20 +36,19 @@ import org.mockito.MockitoAnnotations;
 /** Unit tests for {@link TracezDataAggregator}. */
 @RunWith(JUnit4.class)
 public final class TracezDataAggregatorTest {
-  private final TracerSdkProvider tracerSdkProvider = TracerSdkProvider.builder().build();
+  private final TestClock testClock = TestClock.create();
+  private final TracerSdkProvider tracerSdkProvider =
+      TracerSdkProvider.builder().setClock(testClock).build();
   private final Tracer tracer = tracerSdkProvider.get("TracezDataAggregatorTest");
+  private final TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
+  private final TracezDataAggregator dataAggregator = new TracezDataAggregator(spanProcessor);
   private static final String SPAN_NAME_ONE = "one";
   private static final String SPAN_NAME_TWO = "two";
-
-  private TracezSpanProcessor spanProcessor;
-  private TracezDataAggregator dataAggregator;
 
   @Before
   public void setup() {
     MockitoAnnotations.initMocks(this);
-    spanProcessor = TracezSpanProcessor.newBuilder().build();
     tracerSdkProvider.addSpanProcessor(spanProcessor);
-    dataAggregator = new TracezDataAggregator(spanProcessor);
   }
 
   @Test
@@ -57,6 +58,24 @@ public final class TracezDataAggregatorTest {
     assertThat(counts.size()).isEqualTo(0);
     assertThat(counts.get(SPAN_NAME_ONE)).isNull();
     assertThat(counts.get(SPAN_NAME_TWO)).isNull();
+  }
+
+  @Test
+  public void getRunningSpanCounts_oneSpanName() {
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span3 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    /* getRunningSpanCounts should return a map with 1 span name */
+    Map<String, Integer> counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(1);
+    assertThat(counts.get(SPAN_NAME_ONE)).isEqualTo(3);
+    span1.end();
+    span2.end();
+    span3.end();
+    /* getRunningSpanCounts should return a map with no span names */
+    counts = dataAggregator.getRunningSpanCounts();
+    assertThat(counts.size()).isEqualTo(0);
+    assertThat(counts.get(SPAN_NAME_ONE)).isNull();
   }
 
   @Test
@@ -85,42 +104,8 @@ public final class TracezDataAggregatorTest {
   }
 
   @Test
-  public void getRunningSpanCounts_oneSpanName() {
-    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
-    Span span2 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
-    Span span3 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
-    /* getRunningSpanCounts should return a map with 1 span name */
-    Map<String, Integer> counts = dataAggregator.getRunningSpanCounts();
-    assertThat(counts.size()).isEqualTo(1);
-    assertThat(counts.get(SPAN_NAME_ONE)).isEqualTo(3);
-    span1.end();
-    span2.end();
-    span3.end();
-    /* getRunningSpanCounts should return a map with no span names */
-    counts = dataAggregator.getRunningSpanCounts();
-    assertThat(counts.size()).isEqualTo(0);
-    assertThat(counts.get(SPAN_NAME_ONE)).isNull();
-  }
-
-  @Test
   public void getRunningSpans_noSpans() {
     /* getRunningSpans should return an empty List */
-    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_ONE).size()).isEqualTo(0);
-    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_TWO).size()).isEqualTo(0);
-  }
-
-  @Test
-  public void getRunningSpans_twoSpanNames() {
-    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
-    Span span2 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
-    /* getRunningSpans should return a List with only the corresponding span */
-    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_ONE))
-        .containsExactly(((ReadableSpan) span1).toSpanData());
-    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_TWO))
-        .containsExactly(((ReadableSpan) span2).toSpanData());
-    span1.end();
-    span2.end();
-    /* getRunningSpans should return an empty List for each span name */
     assertThat(dataAggregator.getRunningSpans(SPAN_NAME_ONE).size()).isEqualTo(0);
     assertThat(dataAggregator.getRunningSpans(SPAN_NAME_TWO).size()).isEqualTo(0);
   }
@@ -141,5 +126,111 @@ public final class TracezDataAggregatorTest {
     span3.end();
     /* getRunningSpans should return an empty List */
     assertThat(dataAggregator.getRunningSpans(SPAN_NAME_ONE).size()).isEqualTo(0);
+  }
+
+  @Test
+  public void getRunningSpans_twoSpanNames() {
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
+    /* getRunningSpans should return a List with only the corresponding span */
+    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_ONE))
+        .containsExactly(((ReadableSpan) span1).toSpanData());
+    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_TWO))
+        .containsExactly(((ReadableSpan) span2).toSpanData());
+    span1.end();
+    span2.end();
+    /* getRunningSpans should return an empty List for each span name */
+    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_ONE).size()).isEqualTo(0);
+    assertThat(dataAggregator.getRunningSpans(SPAN_NAME_TWO).size()).isEqualTo(0);
+  }
+
+  @Test
+  public void getSpanLatencyCounts_noSpans() {
+    /* getSpanLatencyCounts should return a an empty map */
+    Map<String, Integer> counts = dataAggregator.getSpanLatencyCounts(0, Long.MAX_VALUE);
+    assertThat(counts.size()).isEqualTo(0);
+    assertThat(counts.get(SPAN_NAME_ONE)).isNull();
+    assertThat(counts.get(SPAN_NAME_TWO)).isNull();
+  }
+
+  @Test
+  public void getSpanLatencyCounts_oneSpanPerLatencyBucket() {
+    for (LatencyBoundaries boundaries : LatencyBoundaries.values()) {
+      Span span = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+      testClock.advanceNanos(boundaries.getLatencyLowerBound());
+      span.end();
+    }
+    /* getSpanLatencyCounts should return 1 span per latency bucket */
+    Map<LatencyBoundaries, Map<String, Integer>> allCounts = dataAggregator.getSpanLatencyCounts();
+    for (LatencyBoundaries boundaries : LatencyBoundaries.values()) {
+      Map<String, Integer> counts =
+          dataAggregator.getSpanLatencyCounts(
+              boundaries.getLatencyLowerBound(), boundaries.getLatencyUpperBound());
+      assertThat(counts.size()).isEqualTo(1);
+      assertThat(counts.get(SPAN_NAME_ONE)).isEqualTo(1);
+      assertThat(counts.entrySet()).isEqualTo(allCounts.get(boundaries).entrySet());
+    }
+  }
+
+  @Test
+  public void getSpanLatencyCounts_upperBoundEdgeCase() {
+    Span span = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    testClock.advanceNanos(1000);
+    span.end();
+    /* getSpanLatencyCounts(0, 1000) should not return the span */
+    Map<String, Integer> counts = dataAggregator.getSpanLatencyCounts(0, 1000);
+    assertThat(counts.size()).isEqualTo(0);
+    assertThat(counts.get(SPAN_NAME_ONE)).isNull();
+    /* getSpanLatencyCounts(1000, Long.MAX_VALUE) should return the span */
+    counts = dataAggregator.getSpanLatencyCounts(1000, Long.MAX_VALUE);
+    assertThat(counts.size()).isEqualTo(1);
+    assertThat(counts.get(SPAN_NAME_ONE)).isEqualTo(1);
+  }
+
+  @Test
+  public void getOkSpans_noSpans() {
+    /* getOkSpans should return an empty List */
+    assertThat(dataAggregator.getOkSpans(SPAN_NAME_ONE, 0, Long.MAX_VALUE).size()).isEqualTo(0);
+    assertThat(dataAggregator.getOkSpans(SPAN_NAME_TWO, 0, Long.MAX_VALUE).size()).isEqualTo(0);
+  }
+
+  @Test
+  public void getOkSpans_oneSpanNameDifferentLatencies() {
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    /* getOkSpans should return an empty List */
+    assertThat(dataAggregator.getOkSpans(SPAN_NAME_ONE, 0, Long.MAX_VALUE).size()).isEqualTo(0);
+    span1.end();
+    testClock.advanceNanos(1000);
+    span2.end();
+    /* getOkSpans should return a List with both spans */
+    List<SpanData> spans = dataAggregator.getOkSpans(SPAN_NAME_ONE, 0, Long.MAX_VALUE);
+    assertThat(spans.size()).isEqualTo(2);
+    assertThat(spans).contains(((ReadableSpan) span1).toSpanData());
+    assertThat(spans).contains(((ReadableSpan) span2).toSpanData());
+    /* getOkSpans should return a List with only the first span */
+    spans = dataAggregator.getOkSpans(SPAN_NAME_ONE, 0, 1000);
+    assertThat(spans.size()).isEqualTo(1);
+    assertThat(spans).contains(((ReadableSpan) span1).toSpanData());
+    /* getOkSpans should return a List with only the second span */
+    spans = dataAggregator.getOkSpans(SPAN_NAME_ONE, 1000, Long.MAX_VALUE);
+    assertThat(spans.size()).isEqualTo(1);
+    assertThat(spans).contains(((ReadableSpan) span2).toSpanData());
+  }
+
+  @Test
+  public void getOkSpans_twoSpanNames() {
+    Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
+    Span span2 = tracer.spanBuilder(SPAN_NAME_TWO).startSpan();
+    /* getOkSpans should return an empty List for each span name */
+    assertThat(dataAggregator.getOkSpans(SPAN_NAME_ONE, 0, Long.MAX_VALUE).size()).isEqualTo(0);
+    assertThat(dataAggregator.getOkSpans(SPAN_NAME_TWO, 0, Long.MAX_VALUE).size()).isEqualTo(0);
+    span1.end();
+    span2.end();
+    /* getOkSpans should return a List with only the corresponding span */
+    assertThat(dataAggregator.getOkSpans(SPAN_NAME_ONE, 0, Long.MAX_VALUE))
+        .containsExactly(((ReadableSpan) span1).toSpanData());
+    assertThat(dataAggregator.getOkSpans(SPAN_NAME_TWO, 0, Long.MAX_VALUE))
+        .containsExactly(((ReadableSpan) span2).toSpanData());
   }
 }

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezDataAggregatorTest.java
@@ -155,20 +155,20 @@ public final class TracezDataAggregatorTest {
 
   @Test
   public void getSpanLatencyCounts_oneSpanPerLatencyBucket() {
-    for (LatencyBoundaries boundaries : LatencyBoundaries.values()) {
+    for (LatencyBoundaries bucket : LatencyBoundaries.values()) {
       Span span = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
-      testClock.advanceNanos(boundaries.getLatencyLowerBound());
+      testClock.advanceNanos(bucket.getLatencyLowerBound());
       span.end();
     }
     /* getSpanLatencyCounts should return 1 span per latency bucket */
     Map<LatencyBoundaries, Map<String, Integer>> allCounts = dataAggregator.getSpanLatencyCounts();
-    for (LatencyBoundaries boundaries : LatencyBoundaries.values()) {
+    for (LatencyBoundaries bucket : LatencyBoundaries.values()) {
       Map<String, Integer> counts =
           dataAggregator.getSpanLatencyCounts(
-              boundaries.getLatencyLowerBound(), boundaries.getLatencyUpperBound());
+              bucket.getLatencyLowerBound(), bucket.getLatencyUpperBound());
       assertThat(counts.size()).isEqualTo(1);
       assertThat(counts.get(SPAN_NAME_ONE)).isEqualTo(1);
-      assertThat(counts.entrySet()).isEqualTo(allCounts.get(boundaries).entrySet());
+      assertThat(counts.entrySet()).isEqualTo(allCounts.get(bucket).entrySet());
     }
   }
 
@@ -195,7 +195,7 @@ public final class TracezDataAggregatorTest {
   }
 
   @Test
-  public void getOkSpans_oneSpanNameDifferentLatencies() {
+  public void getOkSpans_oneSpanNameWithDifferentLatencies() {
     Span span1 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
     Span span2 = tracer.spanBuilder(SPAN_NAME_ONE).startSpan();
     /* getOkSpans should return an empty List */

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessorTest.java
@@ -34,9 +34,9 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-/** Unit tests for {@link TraceZSpanProcessor}. */
+/** Unit tests for {@link TracezSpanProcessor}. */
 @RunWith(JUnit4.class)
-public final class TraceZSpanProcessorTest {
+public final class TracezSpanProcessorTest {
   @Mock private ReadableSpan readableSpan;
   private static final SpanContext SAMPLED_SPAN_CONTEXT =
       SpanContext.create(
@@ -47,7 +47,7 @@ public final class TraceZSpanProcessorTest {
   private static final SpanContext NOT_SAMPLED_SPAN_CONTEXT = SpanContext.getInvalid();
 
   private static void assertSpanCacheSizes(
-      TraceZSpanProcessor spanProcessor, int runningSpanCacheSize, int completedSpanCacheSize) {
+      TracezSpanProcessor spanProcessor, int runningSpanCacheSize, int completedSpanCacheSize) {
     Collection<ReadableSpan> runningSpans = spanProcessor.getRunningSpans();
     Collection<ReadableSpan> completedSpans = spanProcessor.getCompletedSpans();
     assertThat(runningSpans.size()).isEqualTo(runningSpanCacheSize);
@@ -61,7 +61,7 @@ public final class TraceZSpanProcessorTest {
 
   @Test
   public void onStart_sampledSpan_inCache() {
-    TraceZSpanProcessor spanProcessor = TraceZSpanProcessor.newBuilder().build();
+    TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
     /* Return a sampled span, which should be added to the running cache by default */
     when(readableSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
     spanProcessor.onStart(readableSpan);
@@ -70,7 +70,7 @@ public final class TraceZSpanProcessorTest {
 
   @Test
   public void onEnd_sampledSpan_inCache() {
-    TraceZSpanProcessor spanProcessor = TraceZSpanProcessor.newBuilder().build();
+    TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
     /* Return a sampled span, which should be added to the completed cache upon ending */
     when(readableSpan.getSpanContext()).thenReturn(SAMPLED_SPAN_CONTEXT);
     spanProcessor.onStart(readableSpan);
@@ -80,7 +80,7 @@ public final class TraceZSpanProcessorTest {
 
   @Test
   public void onStart_notSampledSpan_notInCache() {
-    TraceZSpanProcessor spanProcessor = TraceZSpanProcessor.newBuilder().build();
+    TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
     /* Return a non-sampled span, which should not be added to the running cache by default */
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     spanProcessor.onStart(readableSpan);
@@ -92,8 +92,8 @@ public final class TraceZSpanProcessorTest {
     /* Initialize a TraceZSpanProcessor that only looks at sampled spans */
     Properties properties = new Properties();
     properties.setProperty("otel.ssp.export.sampled", "true");
-    TraceZSpanProcessor spanProcessor =
-        TraceZSpanProcessor.newBuilder().readProperties(properties).build();
+    TracezSpanProcessor spanProcessor =
+        TracezSpanProcessor.newBuilder().readProperties(properties).build();
 
     /* Return a non-sampled span, which should not be added to the running cache */
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
@@ -106,8 +106,8 @@ public final class TraceZSpanProcessorTest {
     /* Initialize a TraceZSpanProcessor that looks at all spans */
     Properties properties = new Properties();
     properties.setProperty("otel.ssp.export.sampled", "false");
-    TraceZSpanProcessor spanProcessor =
-        TraceZSpanProcessor.newBuilder().readProperties(properties).build();
+    TracezSpanProcessor spanProcessor =
+        TracezSpanProcessor.newBuilder().readProperties(properties).build();
 
     /* Return a non-sampled span, which should be added to the caches */
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);

--- a/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessorTest.java
+++ b/sdk_contrib/zpages/src/test/java/io/opentelemetry/sdk/contrib/zpages/TracezSpanProcessorTest.java
@@ -79,11 +79,21 @@ public final class TracezSpanProcessorTest {
   }
 
   @Test
-  public void onStart_notSampledSpan_notInCache() {
+  public void onStart_notSampledSpan_inCache() {
     TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
     /* Return a non-sampled span, which should not be added to the running cache by default */
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     spanProcessor.onStart(readableSpan);
+    assertSpanCacheSizes(spanProcessor, 1, 0);
+  }
+
+  @Test
+  public void onEnd_notSampledSpan_notInCache() {
+    TracezSpanProcessor spanProcessor = TracezSpanProcessor.newBuilder().build();
+    /* Return a non-sampled span, which should not be added to the running cache by default */
+    when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
+    spanProcessor.onStart(readableSpan);
+    spanProcessor.onEnd(readableSpan);
     assertSpanCacheSizes(spanProcessor, 0, 0);
   }
 
@@ -95,9 +105,11 @@ public final class TracezSpanProcessorTest {
     TracezSpanProcessor spanProcessor =
         TracezSpanProcessor.newBuilder().readProperties(properties).build();
 
-    /* Return a non-sampled span, which should not be added to the running cache */
+    /* Return a non-sampled span, which should not be added to the completed cache */
     when(readableSpan.getSpanContext()).thenReturn(NOT_SAMPLED_SPAN_CONTEXT);
     spanProcessor.onStart(readableSpan);
+    assertSpanCacheSizes(spanProcessor, 1, 0);
+    spanProcessor.onEnd(readableSpan);
     assertSpanCacheSizes(spanProcessor, 0, 0);
   }
 


### PR DESCRIPTION
I talked with Terry to see what needed to be updated and/or moved around.

Key Changes:
* The SpanProcessor now tracks all running spans instead of just sampled spans. This is based on the description provided in [OpenCensus](https://opencensus.io/zpages/java/).
* The DataAggregator has a new function `getSpanNames` that returns all the span names in the running and completed span caches.
* The `getSpanLatencyCount` function in DataAggregator now returns a `Map<SpanName, Map<LatencyBoundaries, Count>>` type to simplify the code on the frontend side.